### PR TITLE
Readd dropped '$' in regex, fix broken check on devel dependency

### DIFF
--- a/TagsCheck.py
+++ b/TagsCheck.py
@@ -640,7 +640,7 @@ class TagsCheck(AbstractCheck.AbstractCheck):
                     base_or_libs = base + '*/' + base + '-libs/lib' + base + '*'
                     # try to match *%_isa as well (e.g. "(x86-64)", "(x86-32)")
                     base_or_libs_re = re.compile(
-                        '^(lib)?%s(-libs)?[\d_]*(\(\w+-\d+\))?' % re.escape(base))
+                        '^(lib)?%s(-libs)?[\d_]*(\(\w+-\d+\))?$' % re.escape(base))
                     for d in deps:
                         if base_or_libs_re.match(d[0]):
                             dep = d


### PR DESCRIPTION
The current regex also maches "Requires: libzork-data", although it should only match e.g. "libzork1" or "zork-libs". As the latter sorts after "libzork-data", an existing correct dependency may be missed.